### PR TITLE
Entity list thumbnails, AABB rulers, and debug camera framing

### DIFF
--- a/packages/editor/index.html
+++ b/packages/editor/index.html
@@ -7,9 +7,13 @@
 	<title>Zylem Editor - Debug UI</title>
 
 	<style>
+		html,
 		body {
 			margin: 0;
 			padding: 0;
+			width: 100%;
+			height: 100%;
+			overflow: hidden;
 			background-color: var(--zylem-color-background);
 		}
 	</style>

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -34,6 +34,7 @@
     "@zylem/game-lib": "workspace:^"
   },
   "devDependencies": {
+    "@zylem/game-lib": "workspace:*",
     "typescript": "6.0.3",
     "vite": "7.0.4",
     "vite-plugin-solid": "^2.11.8"

--- a/packages/editor/src/components/entities/EntitiesSection.tsx
+++ b/packages/editor/src/components/entities/EntitiesSection.tsx
@@ -6,17 +6,22 @@ import { EntityThumbnail } from './EntityThumbnail';
 import { dispatchEditorUpdate } from '../editor-events';
 import { setDebugStore } from '../editor-store';
 import { setSelectedEntityId } from './entities-state';
+import { printToConsole } from '..';
 import type { BaseEntityInterface } from '../../types';
 
 /**
- * Handle entity button click — select the entity and frame the debug camera.
+ * Handle entity button click — log entity info to the editor console, select
+ * the entity, and best-effort frame the debug camera when a live stage focus
+ * context exists (no-op in stub mode).
  */
 function handleEntityClick(entity: Partial<BaseEntityInterface>): void {
 	if (!entity.uuid) return;
-	const focused = focusEntity(entity.uuid);
-	if (!focused) return;
 
+	const { thumbnail: _thumbnail, ...entityInfo } = entity;
+	printToConsole(`Entity: ${JSON.stringify(entityInfo, null, 2)}`);
 	setSelectedEntityId(entity.uuid);
+	focusEntity(entity.uuid);
+
 	if (debugState.enabled) {
 		setDebugStore('debug', true);
 		dispatchEditorUpdate({ gameState: { debugFlag: true } });
@@ -36,7 +41,9 @@ export const EntitiesSection: Component = () => {
 							<button
 								class="entity-grid-item"
 								type="button"
-								title={entity.name ? `${entity.name} (${entity.uuid})` : entity.uuid}
+								title={
+									entity.name ? `${entity.name} (${entity.uuid})` : entity.uuid
+								}
 								onClick={() => handleEntityClick(entity)}
 							>
 								<EntityThumbnail
@@ -45,7 +52,6 @@ export const EntitiesSection: Component = () => {
 									thumbnail={entity.thumbnail}
 									bounds={entity.bounds}
 								/>
-								<span class="entity-grid-name">{entity.name ?? entity.type ?? 'Entity'}</span>
 							</button>
 						)}
 					</For>

--- a/packages/editor/src/components/entities/EntitiesSection.tsx
+++ b/packages/editor/src/components/entities/EntitiesSection.tsx
@@ -1,39 +1,56 @@
 import type { Component } from 'solid-js';
 import { For } from 'solid-js';
+import { focusEntity, debugState } from '@zylem/game-lib/debug';
 import { useEditor } from '../EditorContext';
-import { EntityIcon } from './EntityIcon';
-import { printToConsole } from '..';
+import { EntityThumbnail } from './EntityThumbnail';
+import { dispatchEditorUpdate } from '../editor-events';
+import { setDebugStore } from '../editor-store';
+import { setSelectedEntityId } from './entities-state';
 import type { BaseEntityInterface } from '../../types';
 
 /**
- * Handle entity button click - logs entity debug info to console.
+ * Handle entity button click — select the entity and frame the debug camera.
  */
 function handleEntityClick(entity: Partial<BaseEntityInterface>): void {
-    printToConsole(`Entity: ${JSON.stringify(entity, null, 2)}`);
+	if (!entity.uuid) return;
+	const focused = focusEntity(entity.uuid);
+	if (!focused) return;
+
+	setSelectedEntityId(entity.uuid);
+	if (debugState.enabled) {
+		setDebugStore('debug', true);
+		dispatchEditorUpdate({ gameState: { debugFlag: true } });
+	}
 }
 
 export const EntitiesSection: Component = () => {
-    const { stage } = useEditor();
+	const { stage } = useEditor();
 
-    return (
-        <div class="panel-content">
-            <section class="zylem-section">
-                <h4 class="zylem-section-title">Entities ({stage.entities.length})</h4>
-                <div class="entity-grid">
-                    <For each={stage.entities}>
-                        {(entity) => (
-                            <button
-                                class="entity-grid-item"
-                                title={entity.uuid}
-                                onClick={() => handleEntityClick(entity)}
-                            >
-                                <EntityIcon type={entity.type ?? 'Box'} />
-                            </button>
-                        )}
-                    </For>
-                </div>
-            </section>
-        </div>
-    );
+	return (
+		<div class="panel-content">
+			<section class="zylem-section">
+				<h4 class="zylem-section-title">Entities ({stage.entities.length})</h4>
+				<div class="entity-grid">
+					<For each={stage.entities}>
+						{(entity) => (
+							<button
+								class="entity-grid-item"
+								type="button"
+								title={entity.name ? `${entity.name} (${entity.uuid})` : entity.uuid}
+								onClick={() => handleEntityClick(entity)}
+							>
+								<EntityThumbnail
+									type={entity.type ?? 'Box'}
+									name={entity.name}
+									thumbnail={entity.thumbnail}
+									bounds={entity.bounds}
+								/>
+								<span class="entity-grid-name">{entity.name ?? entity.type ?? 'Entity'}</span>
+							</button>
+						)}
+					</For>
+				</div>
+			</section>
+		</div>
+	);
 };
-

--- a/packages/editor/src/components/entities/EntityIcon.tsx
+++ b/packages/editor/src/components/entities/EntityIcon.tsx
@@ -11,7 +11,7 @@ import Globe from 'lucide-solid/icons/globe';
 
 /**
  * Map entity type strings to lucide-solid icons.
- * Will be replaced with thumbnail previews in the future.
+ * Used as a fallback when a thumbnail preview is unavailable.
  */
 const ICON_MAP: Record<string, Component<{ class?: string }>> = {
 	Box: Box as Component<{ class?: string }>,

--- a/packages/editor/src/components/entities/EntityThumbnail.tsx
+++ b/packages/editor/src/components/entities/EntityThumbnail.tsx
@@ -1,0 +1,59 @@
+import type { Component } from 'solid-js';
+import { Show } from 'solid-js';
+import { EntityIcon } from './EntityIcon';
+
+export interface EntityThumbnailProps {
+	type: string;
+	name?: string | undefined;
+	thumbnail?: string | null | undefined;
+	bounds?: { width: number; height: number; depth: number } | undefined;
+}
+
+function formatDim(value: number): string {
+	if (!Number.isFinite(value)) return '—';
+	if (value >= 10) return value.toFixed(0);
+	if (value >= 1) return value.toFixed(1);
+	return value.toFixed(2);
+}
+
+/**
+ * Entity list preview: 3D thumbnail image (or type icon fallback) with
+ * AABB dimension rulers along the bottom (width) and side (height).
+ */
+export const EntityThumbnail: Component<EntityThumbnailProps> = (props) => {
+	const widthLabel = () => formatDim(props.bounds?.width ?? 0);
+	const heightLabel = () => formatDim(props.bounds?.height ?? 0);
+	const depthLabel = () => formatDim(props.bounds?.depth ?? 0);
+	const hasBounds = () => Boolean(props.bounds);
+
+	return (
+		<div class="entity-thumbnail" title={props.name}>
+			<div class="entity-thumbnail-frame">
+				<Show
+					when={props.thumbnail}
+					fallback={<EntityIcon type={props.type} class="entity-icon" />}
+				>
+					{(src) => (
+						<img
+							class="entity-thumbnail-image"
+							src={src()}
+							alt={props.name ?? props.type}
+							draggable={false}
+						/>
+					)}
+				</Show>
+				<Show when={hasBounds()}>
+					<div class="entity-ruler entity-ruler-bottom" aria-hidden="true">
+						<span class="entity-ruler-ticks" />
+						<span class="entity-ruler-label">{widthLabel()}</span>
+					</div>
+					<div class="entity-ruler entity-ruler-side" aria-hidden="true">
+						<span class="entity-ruler-ticks" />
+						<span class="entity-ruler-label">{heightLabel()}</span>
+					</div>
+					<span class="entity-ruler-depth">d {depthLabel()}</span>
+				</Show>
+			</div>
+		</div>
+	);
+};

--- a/packages/editor/src/components/entities/EntityThumbnail.tsx
+++ b/packages/editor/src/components/entities/EntityThumbnail.tsx
@@ -19,12 +19,14 @@ function formatDim(value: number): string {
 /**
  * Entity list preview: 3D thumbnail image (or type icon fallback) with
  * AABB dimension rulers along the bottom (width) and side (height).
+ * Name caption overlays the bottom of the frame; rulers show on hover.
  */
 export const EntityThumbnail: Component<EntityThumbnailProps> = (props) => {
 	const widthLabel = () => formatDim(props.bounds?.width ?? 0);
 	const heightLabel = () => formatDim(props.bounds?.height ?? 0);
 	const depthLabel = () => formatDim(props.bounds?.depth ?? 0);
 	const hasBounds = () => Boolean(props.bounds);
+	const caption = () => props.name ?? props.type;
 
 	return (
 		<div class="entity-thumbnail" title={props.name}>
@@ -42,6 +44,7 @@ export const EntityThumbnail: Component<EntityThumbnailProps> = (props) => {
 						/>
 					)}
 				</Show>
+				<span class="entity-grid-name">{caption()}</span>
 				<Show when={hasBounds()}>
 					<div class="entity-ruler entity-ruler-bottom" aria-hidden="true">
 						<span class="entity-ruler-ticks" />

--- a/packages/editor/src/components/entities/entity-preview.css.ts
+++ b/packages/editor/src/components/entities/entity-preview.css.ts
@@ -3,18 +3,31 @@
  * Injected alongside @zylem/ui styles in the editor web component.
  */
 export const entityPreviewCSS = `
+.panel-content .zylem-section {
+	padding: 0 10px 10px;
+	box-sizing: border-box;
+}
+
+.panel-content .zylem-section-title {
+	margin: 8px 0 10px;
+}
+
 .entity-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
-	gap: 8px;
-	padding: 4px 0;
+	gap: 16px;
+	padding: 0;
+	margin: 0;
 }
 
 .entity-grid-item {
+	box-sizing: border-box;
+	min-width: 0;
+	width: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
-	gap: 4px;
+	gap: 0;
 	padding: 6px;
 	margin: 0;
 	border: 1px solid color-mix(in srgb, var(--zylem-color-border, #444) 80%, transparent);
@@ -34,23 +47,15 @@ export const entityPreviewCSS = `
 	outline-offset: 1px;
 }
 
-.entity-grid-name {
-	display: block;
-	font-size: 11px;
-	line-height: 1.2;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	opacity: 0.85;
-}
-
 .entity-thumbnail {
 	width: 100%;
+	min-width: 0;
 }
 
 .entity-thumbnail-frame {
 	position: relative;
 	width: 100%;
+	min-width: 0;
 	aspect-ratio: 1;
 	overflow: hidden;
 	border-radius: 4px;
@@ -74,6 +79,25 @@ export const entityPreviewCSS = `
 	opacity: 0.75;
 }
 
+.entity-grid-name {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 2;
+	display: block;
+	padding: 4px 6px;
+	font-size: 11px;
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	text-align: center;
+	color: rgba(255, 255, 255, 0.95);
+	background: rgba(0, 0, 0, 0.45);
+	pointer-events: none;
+}
+
 .entity-ruler {
 	position: absolute;
 	pointer-events: none;
@@ -81,12 +105,38 @@ export const entityPreviewCSS = `
 	font-size: 9px;
 	line-height: 1;
 	font-variant-numeric: tabular-nums;
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.entity-ruler-depth {
+	position: absolute;
+	top: 2px;
+	right: 3px;
+	z-index: 1;
+	font-size: 9px;
+	line-height: 1;
+	padding: 1px 3px;
+	border-radius: 2px;
+	background: rgba(0, 0, 0, 0.45);
+	color: rgba(255, 255, 255, 0.85);
+	font-variant-numeric: tabular-nums;
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.entity-grid-item:hover .entity-ruler,
+.entity-grid-item:hover .entity-ruler-depth,
+.entity-grid-item:focus-within .entity-ruler,
+.entity-grid-item:focus-within .entity-ruler-depth {
+	opacity: 1;
 }
 
 .entity-ruler-bottom {
 	left: 10px;
 	right: 4px;
-	bottom: 2px;
+	/* Sit above the name caption so both stay readable on hover */
+	bottom: 22px;
 	height: 12px;
 	display: flex;
 	align-items: flex-end;
@@ -95,7 +145,7 @@ export const entityPreviewCSS = `
 
 .entity-ruler-side {
 	top: 4px;
-	bottom: 14px;
+	bottom: 36px;
 	left: 1px;
 	width: 12px;
 	display: flex;
@@ -159,18 +209,5 @@ export const entityPreviewCSS = `
 .entity-ruler-side .entity-ruler-label {
 	writing-mode: vertical-rl;
 	transform: rotate(180deg);
-}
-
-.entity-ruler-depth {
-	position: absolute;
-	top: 2px;
-	right: 3px;
-	font-size: 9px;
-	line-height: 1;
-	padding: 1px 3px;
-	border-radius: 2px;
-	background: rgba(0, 0, 0, 0.45);
-	color: rgba(255, 255, 255, 0.85);
-	font-variant-numeric: tabular-nums;
 }
 `;

--- a/packages/editor/src/components/entities/entity-preview.css.ts
+++ b/packages/editor/src/components/entities/entity-preview.css.ts
@@ -1,0 +1,176 @@
+/**
+ * Local styles for entity list thumbnails and AABB dimension rulers.
+ * Injected alongside @zylem/ui styles in the editor web component.
+ */
+export const entityPreviewCSS = `
+.entity-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+	gap: 8px;
+	padding: 4px 0;
+}
+
+.entity-grid-item {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 4px;
+	padding: 6px;
+	margin: 0;
+	border: 1px solid color-mix(in srgb, var(--zylem-color-border, #444) 80%, transparent);
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--zylem-color-surface, #2a2a2a) 90%, transparent);
+	color: inherit;
+	cursor: pointer;
+	text-align: left;
+}
+
+.entity-grid-item:hover {
+	border-color: var(--zylem-color-accent, #6ea8fe);
+}
+
+.entity-grid-item:focus-visible {
+	outline: 2px solid var(--zylem-color-accent, #6ea8fe);
+	outline-offset: 1px;
+}
+
+.entity-grid-name {
+	display: block;
+	font-size: 11px;
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	opacity: 0.85;
+}
+
+.entity-thumbnail {
+	width: 100%;
+}
+
+.entity-thumbnail-frame {
+	position: relative;
+	width: 100%;
+	aspect-ratio: 1;
+	overflow: hidden;
+	border-radius: 4px;
+	background: #3a3a3a;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.entity-thumbnail-image {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+	pointer-events: none;
+}
+
+.entity-thumbnail-frame .entity-icon {
+	width: 40%;
+	height: 40%;
+	opacity: 0.75;
+}
+
+.entity-ruler {
+	position: absolute;
+	pointer-events: none;
+	color: rgba(255, 255, 255, 0.9);
+	font-size: 9px;
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
+}
+
+.entity-ruler-bottom {
+	left: 10px;
+	right: 4px;
+	bottom: 2px;
+	height: 12px;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+}
+
+.entity-ruler-side {
+	top: 4px;
+	bottom: 14px;
+	left: 1px;
+	width: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.entity-ruler-ticks {
+	position: absolute;
+	inset: 0;
+	border: 0 solid rgba(255, 255, 255, 0.55);
+	pointer-events: none;
+}
+
+.entity-ruler-bottom .entity-ruler-ticks {
+	border-top-width: 1px;
+	border-left-width: 1px;
+	border-right-width: 1px;
+	height: 4px;
+	bottom: 0;
+	top: auto;
+	background-image: repeating-linear-gradient(
+		to right,
+		rgba(255, 255, 255, 0.55) 0,
+		rgba(255, 255, 255, 0.55) 1px,
+		transparent 1px,
+		transparent 6px
+	);
+	background-size: 6px 3px;
+	background-repeat: repeat-x;
+	background-position: top left;
+}
+
+.entity-ruler-side .entity-ruler-ticks {
+	border-right-width: 1px;
+	border-top-width: 1px;
+	border-bottom-width: 1px;
+	width: 4px;
+	left: 0;
+	right: auto;
+	background-image: repeating-linear-gradient(
+		to bottom,
+		rgba(255, 255, 255, 0.55) 0,
+		rgba(255, 255, 255, 0.55) 1px,
+		transparent 1px,
+		transparent 6px
+	);
+	background-size: 3px 6px;
+	background-repeat: repeat-y;
+	background-position: top right;
+}
+
+.entity-ruler-label {
+	position: relative;
+	z-index: 1;
+	padding: 0 2px;
+	background: rgba(0, 0, 0, 0.45);
+	border-radius: 2px;
+}
+
+.entity-ruler-side .entity-ruler-label {
+	writing-mode: vertical-rl;
+	transform: rotate(180deg);
+}
+
+.entity-ruler-depth {
+	position: absolute;
+	top: 2px;
+	right: 3px;
+	font-size: 9px;
+	line-height: 1;
+	padding: 1px 3px;
+	border-radius: 2px;
+	background: rgba(0, 0, 0, 0.45);
+	color: rgba(255, 255, 255, 0.85);
+	font-variant-numeric: tabular-nums;
+}
+`;

--- a/packages/editor/src/components/entities/index.ts
+++ b/packages/editor/src/components/entities/index.ts
@@ -1,2 +1,3 @@
 export * from './EntitiesSection';
+export * from './EntityThumbnail';
 export * from './entities-state';

--- a/packages/editor/src/components/stages/stage-state.ts
+++ b/packages/editor/src/components/stages/stage-state.ts
@@ -82,14 +82,21 @@ zylemEventBus.on('state:dispatch', (payload: StateDispatchPayload) => {
 
     // Update entities if present
     if (payload.entities) {
-        stageState.entities = payload.entities.map((e: EntityConfigPayload) => ({
-            uuid: e.uuid,
-            name: e.name,
-            type: e.type,
-            position: e.position,
-            rotation: e.rotation,
-            scale: e.scale,
-        }));
+        stageState.entities = payload.entities.map((e: EntityConfigPayload) => {
+            const next: Partial<BaseEntityInterface> = {
+                uuid: e.uuid,
+                name: e.name,
+                type: e.type,
+                position: e.position,
+                rotation: e.rotation,
+                scale: e.scale,
+                thumbnail: e.thumbnail ?? null,
+            };
+            if (e.bounds) {
+                next.bounds = e.bounds;
+            }
+            return next;
+        });
     }
 });
 

--- a/packages/editor/src/dev/stub-game.ts
+++ b/packages/editor/src/dev/stub-game.ts
@@ -1,0 +1,135 @@
+/**
+ * Standalone stub harness for `pnpm dev:editor`.
+ *
+ * Mounts an empty `<zylem-game>` shell (no WebGL Game instance), emits dummy
+ * `state:dispatch` payloads so editor panels have data, and wires
+ * `attachEditorStateBridge` so toolbar actions update game-lib debug state.
+ */
+
+import '@zylem/game-lib/web-components';
+import {
+	zylemEventBus,
+	type EntityConfigPayload,
+	type StateDispatchPayload,
+} from '@zylem/game-lib/events';
+import { attachEditorStateBridge } from '../host/editor-host';
+
+/**
+ * Build a tiny SVG data-URL thumbnail for stub entity previews.
+ */
+function stubThumbnail(label: string, fill: string): string {
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+		<rect width="96" height="96" fill="#1a1a1e"/>
+		<rect x="16" y="16" width="64" height="64" rx="8" fill="${fill}"/>
+		<text x="48" y="54" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" fill="#fff">${label}</text>
+	</svg>`;
+	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+const STUB_ENTITIES: EntityConfigPayload[] = [
+	{
+		uuid: 'stub-box-001',
+		name: 'Player',
+		type: 'Box',
+		position: { x: 0, y: 1, z: 0 },
+		rotation: { x: 0, y: 0, z: 0 },
+		scale: { x: 1, y: 1, z: 1 },
+		thumbnail: stubThumbnail('Box', '#4a9eff'),
+		bounds: { width: 1, height: 1, depth: 1 },
+	},
+	{
+		uuid: 'stub-sphere-002',
+		name: 'Ball',
+		type: 'Sphere',
+		position: { x: 2, y: 0.5, z: -1 },
+		rotation: { x: 0, y: 0.3, z: 0 },
+		scale: { x: 1, y: 1, z: 1 },
+		thumbnail: stubThumbnail('Sphere', '#ff6b4a'),
+		bounds: { width: 1, height: 1, depth: 1 },
+	},
+	{
+		uuid: 'stub-plane-003',
+		name: 'Ground',
+		type: 'Plane',
+		position: { x: 0, y: 0, z: 0 },
+		rotation: { x: -Math.PI / 2, y: 0, z: 0 },
+		scale: { x: 10, y: 1, z: 10 },
+		thumbnail: stubThumbnail('Plane', '#3d8b5a'),
+		bounds: { width: 10, height: 0.1, depth: 10 },
+	},
+	{
+		uuid: 'stub-gltf-004',
+		name: 'Prop',
+		type: 'GLTF',
+		position: { x: -2, y: 0, z: 1.5 },
+		rotation: { x: 0, y: Math.PI / 4, z: 0 },
+		scale: { x: 1, y: 1, z: 1 },
+		thumbnail: stubThumbnail('GLTF', '#b07cff'),
+		bounds: { width: 1.2, height: 1.8, depth: 0.8 },
+	},
+];
+
+function buildStubPayload(): StateDispatchPayload {
+	return {
+		scope: 'game',
+		path: 'score',
+		value: 42,
+		previousValue: 0,
+		config: {
+			id: 'stub-game',
+			aspectRatio: 16 / 9,
+			fullscreen: false,
+			bodyBackground: '#0d0d10',
+			internalResolution: { width: 1280, height: 720 },
+			debug: true,
+		},
+		stageConfig: {
+			id: 'stub-stage',
+			backgroundColor: '#1a1a22',
+			backgroundImage: null,
+			gravity: { x: 0, y: -9.81, z: 0 },
+			inputs: {
+				p1: ['keyboard-1', 'gamepad-1'],
+				p2: ['keyboard-2', 'gamepad-2'],
+			},
+			variables: {
+				lives: 3,
+				level: 1,
+				paused: false,
+			},
+		},
+		entities: STUB_ENTITIES,
+	};
+}
+
+/**
+ * Create and style the empty `<zylem-game>` shell used as the stub background.
+ */
+export function createStubGameElement(): HTMLElement {
+	const game = document.createElement('zylem-game');
+	game.style.display = 'block';
+	game.style.position = 'absolute';
+	game.style.inset = '0';
+	game.style.width = '100%';
+	game.style.height = '100%';
+	game.style.background =
+		'radial-gradient(ellipse at center, #1e1e28 0%, #0d0d10 70%)';
+	return game;
+}
+
+/**
+ * Wire the editor↔game bridge and emit one dummy `state:dispatch` payload.
+ * Call after `<zylem-editor>` is in the DOM so subscribers are ready.
+ */
+export function bootstrapStubGame(): void {
+	attachEditorStateBridge({
+		onStateDispatch(payload) {
+			console.debug('[editor stub] state dispatch', payload);
+		},
+	});
+
+	// Defer one tick so editor module-level bus subscribers are attached.
+	queueMicrotask(() => {
+		zylemEventBus.emit('state:dispatch', buildStubPayload());
+	});
+}

--- a/packages/editor/src/main.tsx
+++ b/packages/editor/src/main.tsx
@@ -1,17 +1,29 @@
 import '@zylem/ui/styles.css';
 import './web-components/zylem-editor';
+import { bootstrapStubGame, createStubGameElement } from './dev/stub-game';
 
 const root = document.getElementById('root');
 
 if (!root) {
-  throw new Error('Root element not found');
+	throw new Error('Root element not found');
 }
 
-// Create and append the zylem-editor web component
+root.style.position = 'relative';
+root.style.width = '100%';
+root.style.height = '100vh';
+root.style.overflow = 'hidden';
+
+// Empty zylem-game shell (no Game instance / WebGL) behind the editor overlay.
+const game = createStubGameElement();
+root.appendChild(game);
+
 const editor = document.createElement('zylem-editor');
+editor.setAttribute('launcher-mode', 'floating');
 editor.style.display = 'block';
-editor.style.width = '100%';
-editor.style.height = '100vh';
 editor.style.position = 'absolute';
-editor.style.backgroundColor = 'var(--zylem-color-background)';
+editor.style.inset = '0';
+editor.style.width = '100%';
+editor.style.height = '100%';
 root.appendChild(editor);
+
+bootstrapStubGame();

--- a/packages/editor/src/types.ts
+++ b/packages/editor/src/types.ts
@@ -12,10 +12,14 @@ export interface Vector3Like {
 export interface BaseEntityInterface {
 	uuid: string;
 	name: string;
-	type?: string;
-	position?: Vector3Like;
-	rotation?: Vector3Like;
-	scale?: Vector3Like;
+	type?: string | undefined;
+	position?: Vector3Like | undefined;
+	rotation?: Vector3Like | undefined;
+	scale?: Vector3Like | undefined;
+	/** PNG data URL of a framed entity preview. */
+	thumbnail?: string | null | undefined;
+	/** World-space AABB size for thumbnail rulers. */
+	bounds?: { width: number; height: number; depth: number } | undefined;
 }
 
 export interface StageConfigState {

--- a/packages/editor/src/web-components/zylem-editor.tsx
+++ b/packages/editor/src/web-components/zylem-editor.tsx
@@ -8,6 +8,7 @@ import { EditorProvider } from '../components/EditorContext';
 // Import bundled CSS (single file with all tokens and component styles).
 // Resolves via the `./styles.css` export in `@zylem/ui/package.json`.
 import zylemCSS from '@zylem/ui/styles.css?raw';
+import { entityPreviewCSS } from '../components/entities/entity-preview.css';
 
 /**
  * Configuration options for the ZylemEditorElement
@@ -145,7 +146,7 @@ export class ZylemEditorElement extends HTMLElement {
     if (this._config.includeStyles !== false) {
       const styleElement = document.createElement('style');
 
-      styleElement.textContent = zylemCSS;
+      styleElement.textContent = `${zylemCSS}\n${entityPreviewCSS}`;
       this.shadowRoot!.appendChild(styleElement);
     }
 

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -1,23 +1,36 @@
 import { defineConfig } from 'vite';
 import solid from 'vite-plugin-solid';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const devPort = 3332;
 
 // `@zylem/ui/styles.css` is resolved via the package's `exports` map
 // (`"./styles.css": "./dist/styles.css"`), so no explicit alias is needed
 // here — Vite, Rollup, and esbuild all honor the subpath export.
+//
+// Publish builds use `tsup` (`pnpm build`); this config is for `vite` serve
+// (standalone stub harness) and `vite preview` only.
 export default defineConfig({
 	plugins: [solid()],
 	build: {
 		target: 'esnext',
-		lib: {
-			entry: path.resolve(__dirname, 'src/index.ts'),
-			name: 'ZylemEditor',
-			fileName: 'zylem-editor',
-			formats: ['es'],
-		},
-		rollupOptions: {
-			// Externalize deps that shouldn't be bundled locally
-			external: ['solid-js', 'solid-js/web', '@zylem/ui'],
+	},
+	resolve: {
+		// Collapse solid-js onto one copy so `@zylem/ui/components` (shipped as
+		// TSX source) shares the app Solid runtime instead of a duplicate.
+		dedupe: ['solid-js'],
+	},
+	optimizeDeps: {
+		// Keep `@zylem/ui` out of esbuild prebundling so vite-plugin-solid
+		// compiles its TSX components instead of the React JSX transform.
+		exclude: ['@zylem/ui'],
+	},
+	server: {
+		port: devPort,
+		fs: {
+			allow: [path.resolve(__dirname, '..')],
 		},
 	},
 });

--- a/packages/game-lib/src/api/debug.ts
+++ b/packages/game-lib/src/api/debug.ts
@@ -6,5 +6,19 @@ export {
 	debugState,
 	setDebugTool,
 	setPaused,
+	setSelectedEntity,
 	type DebugTools,
 } from '../lib/debug/debug-state';
+
+export {
+	focusEntity,
+	registerEntityFocusContext,
+	type EntityFocusContext,
+} from '../lib/debug/entity-focus';
+
+export {
+	entityThumbnailCache,
+	EntityThumbnailCache,
+	type EntityThumbnailResult,
+	type EntityThumbnailCacheEntry,
+} from '../lib/debug/entity-thumbnail';

--- a/packages/game-lib/src/lib/camera/camera-debug-delegate.ts
+++ b/packages/game-lib/src/lib/camera/camera-debug-delegate.ts
@@ -1,5 +1,6 @@
 import { Object3D, Vector3, Quaternion, Camera, Scene } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { frameObjectFromDirection } from '../debug/frame-object';
 
 export interface CameraDebugState {
 	enabled: boolean;
@@ -145,6 +146,32 @@ export class CameraOrbitController {
 	 */
 	get debugState(): CameraDebugState {
 		return this.debugStateSnapshot;
+	}
+
+	/**
+	 * Frame the camera on an Object3D: center orbit target on its AABB and
+	 * move the camera to a framing distance along the current view direction.
+	 */
+	frameTarget(object: Object3D): void {
+		if (!this.orbitControls && (this.debugStateSnapshot.enabled || this._userOrbitEnabled)) {
+			this.enableOrbitControls();
+		}
+		if (!this.orbitControls) {
+			this.enableOrbitControls();
+		}
+
+		this.orbitTarget = object;
+
+		const direction = new Vector3()
+			.subVectors(this.camera.position, this.orbitControls!.target)
+			.normalize();
+		if (direction.lengthSq() < 1e-8) {
+			direction.set(1, 1, 1).normalize();
+		}
+
+		const bounds = frameObjectFromDirection(object, this.camera, direction);
+		this.orbitControls!.target.copy(bounds.center);
+		this.orbitControls!.update();
 	}
 
 	private applyDebugState(state: CameraDebugState) {

--- a/packages/game-lib/src/lib/camera/zylem-camera.ts
+++ b/packages/game-lib/src/lib/camera/zylem-camera.ts
@@ -366,6 +366,13 @@ export class ZylemCamera {
 		this.orbitController?.setDebugDelegate(delegate);
 	}
 
+	/**
+	 * Frame the debug orbit camera on an Object3D (AABB fit).
+	 */
+	frameObject(object: Object3D): void {
+		this.orbitController?.frameTarget(object);
+	}
+
 	// ─── Movement helpers (backward compat) ─────────────────────────────────
 
 	/**

--- a/packages/game-lib/src/lib/debug/entity-focus.ts
+++ b/packages/game-lib/src/lib/debug/entity-focus.ts
@@ -1,0 +1,64 @@
+import type { Object3D } from 'three';
+import type { GameEntity } from '../entities/entity';
+import { debugState, setSelectedEntity } from './debug-state';
+
+/**
+ * Context registered by the active stage so the editor can focus entities
+ * without importing stage internals.
+ */
+export interface EntityFocusContext {
+	/** Resolve a live entity by UUID from the current stage. */
+	resolveEntity(uuid: string): GameEntity<any> | null;
+	/** Frame the debug camera on an Object3D (group/mesh). */
+	frameObject(object: Object3D): void;
+	/** Ensure debugMap / orbit wiring is ready (e.g. enable debug visuals). */
+	ensureDebugReady?(): void;
+}
+
+let activeContext: EntityFocusContext | null = null;
+
+/**
+ * Register the active stage's focus context. Returns an unregister function.
+ */
+export function registerEntityFocusContext(context: EntityFocusContext): () => void {
+	activeContext = context;
+	return () => {
+		if (activeContext === context) {
+			activeContext = null;
+		}
+	};
+}
+
+/**
+ * Select an entity by UUID and frame the debug camera to fit it.
+ * Enables debug mode so orbit controls are active.
+ *
+ * @returns true if the entity was found and framed
+ */
+export function focusEntity(uuid: string): boolean {
+	if (!activeContext) {
+		console.warn('focusEntity: no active stage focus context');
+		return false;
+	}
+
+	const entity = activeContext.resolveEntity(uuid);
+	if (!entity) {
+		console.warn(`focusEntity: entity ${uuid} not found`);
+		return false;
+	}
+
+	const target = (entity as any).group ?? (entity as any).mesh ?? null;
+	if (!target) {
+		console.warn(`focusEntity: entity ${uuid} has no group/mesh`);
+		return false;
+	}
+
+	if (!debugState.enabled) {
+		debugState.enabled = true;
+	}
+	activeContext.ensureDebugReady?.();
+
+	setSelectedEntity(entity);
+	activeContext.frameObject(target);
+	return true;
+}

--- a/packages/game-lib/src/lib/debug/entity-thumbnail.ts
+++ b/packages/game-lib/src/lib/debug/entity-thumbnail.ts
@@ -1,0 +1,186 @@
+import {
+	DirectionalLight,
+	Object3D,
+	PerspectiveCamera,
+	RenderTarget,
+	Scene,
+	Color,
+	LinearFilter,
+} from 'three';
+import type { WebGPURenderer } from 'three/webgpu';
+import { frameObject, type ObjectBounds } from './frame-object';
+
+export interface EntityThumbnailResult {
+	dataUrl: string;
+	bounds: Pick<ObjectBounds, 'width' | 'height' | 'depth'>;
+}
+
+export interface EntityThumbnailCacheEntry extends EntityThumbnailResult {
+	uuid: string;
+}
+
+const DEFAULT_SIZE = 128;
+
+/**
+ * Generates and caches entity thumbnail previews for the editor entity list.
+ * Renders a cloned Object3D into an offscreen RenderTarget on the shared WebGPU renderer.
+ */
+export class EntityThumbnailCache {
+	private cache = new Map<string, EntityThumbnailCacheEntry>();
+	private inFlight = new Map<string, Promise<EntityThumbnailCacheEntry | null>>();
+	private renderer: WebGPURenderer | null = null;
+	private size: number;
+
+	constructor(size = DEFAULT_SIZE) {
+		this.size = size;
+	}
+
+	setRenderer(renderer: WebGPURenderer | null): void {
+		this.renderer = renderer;
+	}
+
+	get(uuid: string): EntityThumbnailCacheEntry | null {
+		return this.cache.get(uuid) ?? null;
+	}
+
+	invalidate(uuid: string): void {
+		this.cache.delete(uuid);
+		this.inFlight.delete(uuid);
+	}
+
+	clear(): void {
+		this.cache.clear();
+		this.inFlight.clear();
+	}
+
+	/**
+	 * Return a cached thumbnail or generate one asynchronously.
+	 */
+	async ensure(
+		uuid: string,
+		object: Object3D | null | undefined,
+	): Promise<EntityThumbnailCacheEntry | null> {
+		const cached = this.cache.get(uuid);
+		if (cached) return cached;
+
+		const pending = this.inFlight.get(uuid);
+		if (pending) return pending;
+
+		if (!object || !this.renderer) {
+			return null;
+		}
+
+		const task = this.render(uuid, object)
+			.then((result) => {
+				this.inFlight.delete(uuid);
+				if (!result) return null;
+				this.cache.set(uuid, result);
+				return result;
+			})
+			.catch((error) => {
+				this.inFlight.delete(uuid);
+				console.warn('EntityThumbnailCache: failed to render thumbnail', uuid, error);
+				return null;
+			});
+
+		this.inFlight.set(uuid, task);
+		return task;
+	}
+
+	private async render(
+		uuid: string,
+		object: Object3D,
+	): Promise<EntityThumbnailCacheEntry | null> {
+		const renderer = this.renderer;
+		if (!renderer) return null;
+
+		const thumbScene = new Scene();
+		thumbScene.background = new Color(0x3a3a3a);
+
+		const light = new DirectionalLight(0xffffff, 2);
+		light.position.set(5, 10, 7);
+		thumbScene.add(light);
+
+		const clone = object.clone(true);
+		// Normalize transform so framing is relative to the mesh itself
+		clone.position.set(0, 0, 0);
+		clone.rotation.set(0, 0, 0);
+		clone.updateMatrixWorld(true);
+		thumbScene.add(clone);
+
+		const thumbCam = new PerspectiveCamera(50, 1, 0.1, 100);
+		const bounds = frameObject(clone, thumbCam);
+
+		const rt = new RenderTarget(this.size, this.size, {
+			minFilter: LinearFilter,
+			magFilter: LinearFilter,
+		});
+
+		const prevTarget = renderer.getRenderTarget();
+		const prevScissor = renderer.getScissorTest();
+		try {
+			renderer.setScissorTest(false);
+			renderer.setRenderTarget(rt);
+			renderer.render(thumbScene, thumbCam);
+		} finally {
+			renderer.setRenderTarget(prevTarget);
+			renderer.setScissorTest(prevScissor);
+		}
+
+		const buffer = await renderer.readRenderTargetPixelsAsync(
+			rt,
+			0,
+			0,
+			this.size,
+			this.size,
+		);
+
+		rt.dispose();
+		// Do not dispose geometries/materials — Object3D.clone shares them with the live entity.
+		thumbScene.remove(clone);
+
+		const dataUrl = pixelsToDataUrl(buffer, this.size, this.size);
+		if (!dataUrl) return null;
+
+		return {
+			uuid,
+			dataUrl,
+			bounds: {
+				width: bounds.width,
+				height: bounds.height,
+				depth: bounds.depth,
+			},
+		};
+	}
+}
+
+/** Shared cache used by the running game to feed editor entity payloads. */
+export const entityThumbnailCache = new EntityThumbnailCache();
+
+function pixelsToDataUrl(
+	buffer: ArrayBufferView,
+	width: number,
+	height: number,
+): string | null {
+	if (typeof document === 'undefined') return null;
+
+	const canvas = document.createElement('canvas');
+	canvas.width = width;
+	canvas.height = height;
+	const ctx = canvas.getContext('2d');
+	if (!ctx) return null;
+
+	const src = buffer instanceof Uint8Array
+		? buffer
+		: new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+
+	const imageData = ctx.createImageData(width, height);
+	// WebGPU/WebGL readback is bottom-up; flip vertically for canvas.
+	for (let y = 0; y < height; y += 1) {
+		const srcRow = (height - 1 - y) * width * 4;
+		const dstRow = y * width * 4;
+		imageData.data.set(src.subarray(srcRow, srcRow + width * 4), dstRow);
+	}
+	ctx.putImageData(imageData, 0, 0);
+	return canvas.toDataURL('image/png');
+}

--- a/packages/game-lib/src/lib/debug/frame-object.ts
+++ b/packages/game-lib/src/lib/debug/frame-object.ts
@@ -1,0 +1,99 @@
+import {
+	Box3,
+	type Camera,
+	type Object3D,
+	PerspectiveCamera,
+	Vector3,
+} from 'three';
+
+const _box = new Box3();
+const _size = new Vector3();
+const _center = new Vector3();
+const _offset = new Vector3();
+
+export interface ObjectBounds {
+	width: number;
+	height: number;
+	depth: number;
+	center: Vector3;
+	maxDim: number;
+}
+
+/**
+ * Compute the world-space AABB size and center for an Object3D.
+ */
+export function getObjectBounds(object: Object3D): ObjectBounds {
+	_box.setFromObject(object);
+	_box.getSize(_size);
+	_box.getCenter(_center);
+
+	const width = Math.max(_size.x, 1e-4);
+	const height = Math.max(_size.y, 1e-4);
+	const depth = Math.max(_size.z, 1e-4);
+	const maxDim = Math.max(width, height, depth);
+
+	return {
+		width,
+		height,
+		depth,
+		center: _center.clone(),
+		maxDim,
+	};
+}
+
+/**
+ * Distance needed for a perspective camera to fit `maxDim` in view.
+ */
+export function framingDistance(maxDim: number, camera: PerspectiveCamera, padding = 1.35): number {
+	const fov = camera.fov * (Math.PI / 180);
+	const distance = (maxDim / (2 * Math.tan(fov / 2))) * padding;
+	return Math.max(distance, 0.5);
+}
+
+/**
+ * Position a perspective camera to frame an object (isometric-ish offset).
+ * Mutates `camera` in place.
+ */
+export function frameObject(object: Object3D, camera: PerspectiveCamera, padding = 1.35): ObjectBounds {
+	const bounds = getObjectBounds(object);
+	const distance = framingDistance(bounds.maxDim, camera, padding);
+
+	camera.position.copy(bounds.center).add(new Vector3(distance, distance, distance));
+	camera.lookAt(bounds.center);
+	camera.near = Math.max(distance / 100, 0.01);
+	camera.far = Math.max(distance * 20, 100);
+	camera.updateProjectionMatrix();
+
+	return bounds;
+}
+
+/**
+ * Place `camera` so it looks at `object`'s AABB center from the given direction,
+ * at a framing distance. Used by debug orbit framing.
+ */
+export function frameObjectFromDirection(
+	object: Object3D,
+	camera: Camera,
+	direction: Vector3,
+	padding = 1.5,
+): ObjectBounds {
+	const bounds = getObjectBounds(object);
+	const dir = _offset.copy(direction);
+	if (dir.lengthSq() < 1e-8) {
+		dir.set(1, 1, 1);
+	}
+	dir.normalize();
+
+	let distance = bounds.maxDim * padding;
+	if (camera instanceof PerspectiveCamera) {
+		distance = framingDistance(bounds.maxDim, camera, padding);
+		camera.near = Math.max(distance / 100, 0.01);
+		camera.far = Math.max(distance * 20, 100);
+		camera.updateProjectionMatrix();
+	}
+
+	camera.position.copy(bounds.center).addScaledVector(dir, distance);
+	camera.lookAt(bounds.center);
+
+	return bounds;
+}

--- a/packages/game-lib/src/lib/events/zylem-events.ts
+++ b/packages/game-lib/src/lib/events/zylem-events.ts
@@ -31,6 +31,10 @@ export interface EntityConfigPayload {
 	position: { x: number; y: number; z: number };
 	rotation: { x: number; y: number; z: number };
 	scale: { x: number; y: number; z: number };
+	/** PNG data URL of a framed entity preview, when available. */
+	thumbnail?: string | null;
+	/** World-space AABB size used for thumbnail rulers. */
+	bounds?: { width: number; height: number; depth: number };
 }
 
 /** Payload for state dispatch events from game to editor. */

--- a/packages/game-lib/src/lib/game/zylem-game.ts
+++ b/packages/game-lib/src/lib/game/zylem-game.ts
@@ -1,6 +1,7 @@
 import { state, setGlobal, getGlobals, initGlobals, resetGlobals } from './game-state';
 
 import { debugState, isPaused, setDebugFlag } from '../debug/debug-state';
+import { entityThumbnailCache } from '../debug/entity-thumbnail';
 
 import { Game } from './game';
 import { UpdateContext, SetupContext, DestroyContext } from '../core/base-node-life-cycle';
@@ -83,6 +84,7 @@ export class ZylemGame<TGlobals extends BaseGlobals> {
 	private loadingDelegate: GameLoadingDelegate = new GameLoadingDelegate();
 	private rendererObserver: GameRendererObserver = new GameRendererObserver();
 	private eventBusUnsubscribes: (() => void)[] = [];
+	private thumbnailUnsubscribes: (() => void)[] = [];
 	private readonly gameUpdateParams = {} as UpdateContext<
 		ZylemGame<TGlobals>,
 		TGlobals
@@ -233,12 +235,16 @@ export class ZylemGame<TGlobals extends BaseGlobals> {
 			await this.rendererManager.initRenderer();
 		}
 
+		entityThumbnailCache.setRenderer(this.rendererManager.renderer);
+
 		// Start stage loading with shared renderer manager
 		await stage.load(this.id, config?.camera as ZylemCamera | null, this.rendererManager);
 
 		this.stageMap.set(stage.wrappedStage!.uuid, stage);
 		this.currentStageId = stage.wrappedStage!.uuid;
 		this.defaultCamera = stage.wrappedStage!.cameraRef!;
+
+		this.wireEntityThumbnails(stage);
 		
 		// Trigger renderer observer with renderer manager
 		this.rendererObserver.setStage(stage.wrappedStage ?? null);
@@ -300,6 +306,9 @@ export class ZylemGame<TGlobals extends BaseGlobals> {
 		if (!this.currentStageId) return;
 		const current = this.getStage(this.currentStageId);
 		if (!current) return;
+
+		this.clearEntityThumbnailWiring();
+		entityThumbnailCache.clear();
 
 		// Disconnect input config callback from outgoing stage
 		current.onInputConfigChanged = null;
@@ -457,6 +466,7 @@ export class ZylemGame<TGlobals extends BaseGlobals> {
 
 		// Dispose the shared renderer manager
 		if (this.rendererManager) {
+			entityThumbnailCache.setRenderer(null);
 			this.rendererManager.dispose();
 			this.rendererManager = null;
 		}
@@ -539,6 +549,8 @@ export class ZylemGame<TGlobals extends BaseGlobals> {
 			const rotation = (child as any).rotation ?? { x: 0, y: 0, z: 0 };
 			const scale = (child as any).scale ?? { x: 1, y: 1, z: 1 };
 
+			const thumb = entityThumbnailCache.get(child.uuid);
+
 			entities.push({
 				uuid: child.uuid,
 				name: child.name || 'Unnamed',
@@ -546,10 +558,66 @@ export class ZylemGame<TGlobals extends BaseGlobals> {
 				position: { x: position.x ?? 0, y: position.y ?? 0, z: position.z ?? 0 },
 				rotation: { x: rotation.x ?? 0, y: rotation.y ?? 0, z: rotation.z ?? 0 },
 				scale: { x: scale.x ?? 1, y: scale.y ?? 1, z: scale.z ?? 1 },
+				thumbnail: thumb?.dataUrl ?? null,
+				bounds: thumb?.bounds,
 			});
 		});
 
 		return entities;
+	}
+
+	/**
+	 * Generate entity thumbnails as entities become available, then refresh editor state.
+	 */
+	private wireEntityThumbnails(stage: Stage): void {
+		this.clearEntityThumbnailWiring();
+		if (!stage.wrappedStage) return;
+
+		const queueThumbnail = (child: { uuid: string; group?: any; mesh?: any }) => {
+			const object = child.group ?? child.mesh ?? null;
+			if (!object) return;
+			void entityThumbnailCache.ensure(child.uuid, object).then((result) => {
+				if (result) {
+					this.emitStateDispatch('@entity:thumbnail');
+				}
+			});
+		};
+
+		const unsubAdded = stage.wrappedStage.onEntityAdded((child) => {
+			queueThumbnail(child as any);
+		}, { replayExisting: true });
+		this.thumbnailUnsubscribes.push(unsubAdded);
+
+		const onModelLoaded = (payload: { entityId: string; success: boolean }) => {
+			if (!payload.success) return;
+			const child = stage.wrappedStage?.entityDelegate.childrenMap.get(payload.entityId);
+			if (child) {
+				entityThumbnailCache.invalidate(payload.entityId);
+				queueThumbnail(child as any);
+			}
+		};
+		zylemEventBus.on('entity:model:loaded', onModelLoaded);
+		this.thumbnailUnsubscribes.push(() => {
+			zylemEventBus.off('entity:model:loaded', onModelLoaded);
+		});
+
+		const onDestroyed = (payload: { entityId: string }) => {
+			entityThumbnailCache.invalidate(payload.entityId);
+			this.emitStateDispatch('@entity:destroyed');
+		};
+		zylemEventBus.on('entity:destroyed', onDestroyed);
+		this.thumbnailUnsubscribes.push(() => {
+			zylemEventBus.off('entity:destroyed', onDestroyed);
+		});
+	}
+
+	private clearEntityThumbnailWiring(): void {
+		this.thumbnailUnsubscribes.forEach((fn) => {
+			try {
+				fn();
+			} catch { /* noop */ }
+		});
+		this.thumbnailUnsubscribes = [];
 	}
 
 	/**

--- a/packages/game-lib/src/lib/stage/stage-camera-debug-delegate.ts
+++ b/packages/game-lib/src/lib/stage/stage-camera-debug-delegate.ts
@@ -32,6 +32,7 @@ export class StageCameraDebugDelegate implements CameraDebugDelegate {
 
 	resolveTarget(uuid: string): Object3D | null {
 		const entity: any = this.stage.entityDelegate.debugMap.get(uuid)
+			|| this.stage.entityDelegate.childrenMap.get(uuid)
 			|| this.stage.world?.collisionMap.get(uuid)
 			|| null;
 		const target = entity?.group ?? entity?.mesh ?? null;

--- a/packages/game-lib/src/lib/stage/stage-debug-delegate.ts
+++ b/packages/game-lib/src/lib/stage/stage-debug-delegate.ts
@@ -17,7 +17,10 @@ import { subscribe } from 'valtio/vanilla';
 import { ZylemStage } from './zylem-stage';
 import { StageCameraDebugDelegate } from './stage-camera-debug-delegate';
 import { debugState, getDebugTool, getHoveredEntity, resetHoveredEntity, setHoveredEntity, setSelectedEntity } from '../debug/debug-state';
+import { registerEntityFocusContext } from '../debug/entity-focus';
 import { DebugEntityCursor } from './debug-entity-cursor';
+import type { GameEntity } from '../entities/entity';
+import type { BaseNode } from '../core/base-node';
 
 export type AddEntityFactory = (params: { position: Vector3; normal?: Vector3 }) => Promise<any> | any;
 
@@ -51,6 +54,7 @@ export class StageDebugDelegate {
 	private boundColliderPositions: Float32Array | null = null;
 	private cameraDebugDelegate: StageCameraDebugDelegate | null = null;
 	private debugStateUnsubscribe: (() => void) | null = null;
+	private focusContextUnregister: (() => void) | null = null;
 
 	constructor(stage: ZylemStage, options?: StageDebugDelegateOptions) {
 		this.stage = stage;
@@ -64,6 +68,46 @@ export class StageDebugDelegate {
 		this.debugStateUnsubscribe = subscribe(debugState, () => {
 			this.syncWithDebugState();
 		});
+
+		this.focusContextUnregister = registerEntityFocusContext({
+			resolveEntity: (uuid) => this.resolveEntity(uuid),
+			frameObject: (object) => {
+				this.ensureCameraDebugDelegate();
+				this.stage.cameraRef?.frameObject(object);
+			},
+			ensureDebugReady: () => {
+				if (!debugState.enabled) {
+					debugState.enabled = true;
+				}
+				this.activate();
+				this.populateDebugMap();
+			},
+		});
+	}
+
+	private resolveEntity(uuid: string): GameEntity<any> | null {
+		const fromDebug = this.stage.entityDelegate.debugMap.get(uuid);
+		if (fromDebug) return fromDebug as GameEntity<any>;
+
+		const fromChildren = this.stage.entityDelegate.childrenMap.get(uuid);
+		if (fromChildren) return fromChildren as GameEntity<any>;
+
+		const fromCollision = this.stage.world?.collisionMap.get(uuid) as GameEntity<any> | undefined;
+		return fromCollision ?? null;
+	}
+
+	/** Copy all stage children into debugMap so raycast/select tools work after enabling debug mid-session. */
+	private populateDebugMap(): void {
+		this.stage.entityDelegate.childrenMap.forEach((entity: BaseNode, uuid: string) => {
+			this.stage.entityDelegate.debugMap.set(uuid, entity);
+		});
+	}
+
+	private ensureCameraDebugDelegate(): void {
+		if (this.stage.cameraRef && !this.cameraDebugDelegate) {
+			this.cameraDebugDelegate = new StageCameraDebugDelegate(this.stage);
+			this.stage.cameraRef.setDebugDelegate(this.cameraDebugDelegate);
+		}
 	}
 
 	private syncWithDebugState(): void {
@@ -81,10 +125,8 @@ export class StageDebugDelegate {
 			this.domListenersAttached = true;
 		}
 
-		if (this.stage.cameraRef && !this.cameraDebugDelegate) {
-			this.cameraDebugDelegate = new StageCameraDebugDelegate(this.stage);
-			this.stage.cameraRef.setDebugDelegate(this.cameraDebugDelegate);
-		}
+		this.populateDebugMap();
+		this.ensureCameraDebugDelegate();
 	}
 
 	/** Tear down visuals and camera debug delegate when debug is turned off. */
@@ -290,6 +332,8 @@ export class StageDebugDelegate {
 
 	/** Full teardown — unsubscribes from debugState and cleans up all resources. */
 	dispose(): void {
+		this.focusContextUnregister?.();
+		this.focusContextUnregister = null;
 		this.debugStateUnsubscribe?.();
 		this.debugStateUnsubscribe = null;
 		this.deactivate();
@@ -303,8 +347,8 @@ export class StageDebugDelegate {
 		switch (tool) {
 			case 'select': {
 				if (hoveredUuid) {
-					const entity = this.stage.entityDelegate.debugMap.get(hoveredUuid);
-					if (entity) setSelectedEntity(entity as any);
+					const entity = this.resolveEntity(hoveredUuid);
+					if (entity) setSelectedEntity(entity);
 				}
 				break;
 			}

--- a/packages/game-lib/tests/unit/debug/frame-object.spec.ts
+++ b/packages/game-lib/tests/unit/debug/frame-object.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { BoxGeometry, Mesh, MeshBasicMaterial, PerspectiveCamera } from 'three';
+import { frameObject, framingDistance, getObjectBounds } from '../../../src/lib/debug/frame-object';
+
+describe('frame-object', () => {
+	it('computes AABB bounds for a unit box', () => {
+		const mesh = new Mesh(new BoxGeometry(2, 4, 6), new MeshBasicMaterial());
+		const bounds = getObjectBounds(mesh);
+		expect(bounds.width).toBeCloseTo(2, 5);
+		expect(bounds.height).toBeCloseTo(4, 5);
+		expect(bounds.depth).toBeCloseTo(6, 5);
+		expect(bounds.maxDim).toBeCloseTo(6, 5);
+	});
+
+	it('frames a perspective camera to look at the object center', () => {
+		const mesh = new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial());
+		mesh.position.set(10, 0, 0);
+		mesh.updateMatrixWorld(true);
+
+		const camera = new PerspectiveCamera(50, 1, 0.1, 100);
+		const bounds = frameObject(mesh, camera);
+
+		expect(bounds.center.x).toBeCloseTo(10, 4);
+		expect(camera.position.x).toBeGreaterThan(10);
+		expect(camera.position.y).toBeGreaterThan(0);
+		expect(camera.position.z).toBeGreaterThan(0);
+
+		const expected = framingDistance(bounds.maxDim, camera);
+		const distance = camera.position.distanceTo(bounds.center);
+		expect(distance).toBeCloseTo(expected * Math.sqrt(3), 4);
+	});
+
+	it('uses a positive framing distance', () => {
+		const camera = new PerspectiveCamera(60, 1, 0.1, 100);
+		expect(framingDistance(0, camera)).toBeGreaterThan(0);
+		expect(framingDistance(2, camera)).toBeGreaterThan(1);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@solidjs/router':
         specifier: ^0.14.0
         version: 0.14.10(solid-js@1.9.9)
-      '@zylem/game-lib':
-        specifier: workspace:^
-        version: link:../game-lib
       '@zylem/ui':
         specifier: 'catalog:'
         version: 0.2.0(solid-js@1.9.9)
@@ -91,6 +88,9 @@ importers:
         specifier: ^2.1.7
         version: 2.1.7(react@18.3.1)
     devDependencies:
+      '@zylem/game-lib':
+        specifier: workspace:*
+        version: link:../game-lib
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Three.js thumbnail previews to the editor **Entities** panel, with AABB dimension rulers and click-to-frame on the debug camera.

## Changes

### game-lib
- `EntityThumbnailCache` renders framed entity clones offscreen via the shared WebGPU renderer and caches PNG data URLs + AABB bounds
- Extends `EntityConfigPayload` with `thumbnail` and `bounds`; regenerates on entity add / model load
- `CameraOrbitController.frameTarget` + public `focusEntity(uuid)` API (selects entity, enables debug, frames orbit camera)
- Stage debug delegate registers focus context and populates `debugMap` when debug is enabled

### editor
- `EntityThumbnail` shows preview image (or type icon fallback) with width/height rulers and depth label
- Entity click calls `focusEntity` and syncs the debug toolbar flag
- Injects local entity-preview CSS in the `zylem-editor` web component

## Test plan
- [ ] Open a demo with the editor overlay and load a stage with multiple entities
- [ ] Confirm Entities panel shows thumbnails (not only icons) with ruler labels matching entity size
- [ ] Click an entity: debug mode turns on, orbit camera centers and zooms to fit the entity
- [ ] Actors with deferred model load eventually get thumbnails after model load
- [ ] `pnpm --filter @zylem/game-lib exec vitest run tests/unit/debug/frame-object.spec.ts` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-990f9ea1-8478-4d78-aebe-6dab4788963f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-990f9ea1-8478-4d78-aebe-6dab4788963f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

